### PR TITLE
Use datetime.datetime, rename days

### DIFF
--- a/pyportfolio/scheme.py
+++ b/pyportfolio/scheme.py
@@ -47,7 +47,10 @@ class Scheme:
 
     def __update_transaction_details(self):
         for transaction in self.transactions:
-            transaction["Days"] = (datetime.date.today() - transaction["date"]).days
+            t_date = transaction["date"]
+            transaction["days"] = (datetime.date.today() - t_date).days
+            # Change to datetime object
+            transaction["date"] = datetime.datetime(t_date.year, t_date.month, t_date.day)
 
     @property
     def valuation(self):
@@ -105,7 +108,7 @@ class Scheme:
                 map(
                     lambda x: {
                         "Date": x["date"],
-                        "Days": x["Days"],
+                        "Days": x["days"],
                         "Amount": x["amount"],
                         "Units": x["units"],
                         "NAV": x["nav"],

--- a/pyportfolio/transaction_filters.py
+++ b/pyportfolio/transaction_filters.py
@@ -1,5 +1,6 @@
 def get_transaction_type_filter(transaction_type):
     return lambda transaction: transaction["type"] == transaction_type
-    
+
+
 def get_transaction_older_than_filter(days):
-    return lambda transaction: transaction["Days"] > days
+    return lambda transaction: transaction["days"] > days


### PR DESCRIPTION
Mongodb does not support datetime.date objects. So using datetime.datetime to help interoperability.
Rename "Days" to "days"